### PR TITLE
Laravel Model Cachingをやってみた

### DIFF
--- a/app/Constants/Cache.php
+++ b/app/Constants/Cache.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Constants;
+
+final class Cache
+{
+    const CACHE_COMMENT = ':comments';
+
+    public static function cacheKey(string $table, int $key, int $timestamp): string
+    {
+        return sprintf(
+            '%s/%s-%s',
+            $table,
+            $key,
+            $timestamp
+        );
+    }
+
+    public static function getCommentsCache(string $table, int $key, int $timestamp): string
+    {
+        return self::cacheKey($table, $key, $timestamp) . self::CACHE_COMMENT;
+    }
+}

--- a/app/Models/Comments.php
+++ b/app/Models/Comments.php
@@ -16,7 +16,7 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Models\Comments query()
  * @mixin \Eloquent
  */
-class Comments extends Model
+final class Comments extends Model
 {
     /**
      * @var array

--- a/app/Models/Comments.php
+++ b/app/Models/Comments.php
@@ -18,6 +18,13 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Comments extends Model
 {
+    /**
+     * @var array
+     *
+     * @see Model::$touches
+     */
+    protected $touches = ['posts'];
+
     public function posts()
     {
         return $this->belongsTo(Posts::class);

--- a/app/Models/Posts.php
+++ b/app/Models/Posts.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Illuminate\Database\Eloquent\Collection|\App\Models\Comments[] $comments
  * @property mixed                                                           $cached_comments
  */
-class Posts extends Model
+final class Posts extends Model
 {
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasMany

--- a/app/Models/Posts.php
+++ b/app/Models/Posts.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Constants\Cache;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -15,6 +16,7 @@ use Illuminate\Database\Eloquent\Model;
  * @mixin \Eloquent
  *
  * @property \Illuminate\Database\Eloquent\Collection|\App\Models\Comments[] $comments
+ * @property mixed                                                           $cached_comments
  */
 class Posts extends Model
 {
@@ -24,5 +26,18 @@ class Posts extends Model
     public function comments()
     {
         return $this->hasMany(Comments::class);
+    }
+
+    public function getCachedCommentsAttribute()
+    {
+        $key = Cache::getCommentsCache(
+            $this->getTable(),
+            $this->getKey(),
+            $this->updated_at->timestamp
+        );
+
+        return \Cache::remember($key, 1, function () {
+            return $this->comments->toArray();
+        });
     }
 }

--- a/tests/Unit/Models/PostsTest.php
+++ b/tests/Unit/Models/PostsTest.php
@@ -66,6 +66,9 @@ class PostsTest extends TestCase
         $this->assertSameSize($comment, $posts->cachedComments);
         $this->assertTrue(\Cache::has($key));
 
+        // update_atが同じだとテストがエラーになるため1秒待つ
+        sleep(1);
+
         // setup
         $comment[] = factory(Comments::class)->create(
             [

--- a/tests/Unit/Models/PostsTest.php
+++ b/tests/Unit/Models/PostsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Constants\Cache;
+use App\Models\Comments;
+use App\Models\Posts;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PostsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * キャッシュに登録されているか.
+     *
+     * @test
+     */
+    public function testCachedComment()
+    {
+        // setup
+        $posts = factory(Posts::class)->create();
+        $comment = factory(Comments::class, 5)->create(
+            [
+                'posts_id' => $posts->id,
+            ]
+        );
+
+        // exercise
+        $key = Cache::getCommentsCache(
+            $posts->getTable(),
+            $posts->getKey(),
+            $posts->updated_at->timestamp
+        );
+
+        // verify
+        $this->assertSameSize($comment->toArray(), $posts->cachedComments);
+        $this->assertTrue(\Cache::has($key));
+    }
+
+    /**
+     * キャッシュが更新されているか.
+     *
+     * @test
+     */
+    public function testCachedCommentUpdate()
+    {
+        // setup
+        $posts = factory(Posts::class)->create();
+        $comment = factory(Comments::class, 5)->create(
+            [
+                'posts_id' => $posts->id,
+            ]
+        )->toArray();
+
+        // exercise
+        $key = Cache::getCommentsCache(
+            $posts->getTable(),
+            $posts->getKey(),
+            $posts->updated_at->timestamp
+        );
+
+        $this->assertSameSize($comment, $posts->cachedComments);
+        $this->assertTrue(\Cache::has($key));
+
+        // setup
+        $comment[] = factory(Comments::class)->create(
+            [
+                'posts_id' => $posts->id,
+            ]
+        )->toArray();
+
+        // exercise
+        $posts2 = Posts::find($posts->id);
+
+        // verify
+        $this->assertSameSize($comment, $posts2->cachedComments);
+        $key = Cache::getCommentsCache(
+            $posts2->getTable(),
+            $posts2->getKey(),
+            $posts2->updated_at->timestamp
+        );
+        $this->assertTrue(\Cache::has($key));
+    }
+}


### PR DESCRIPTION
## 概要
[Laravel Model Caching - Laravel News](https://laravel-news.com/laravel-model-caching)を元に、Cacheの処理を作成

## やったこと
* Cacheの定数ファイルを作成
* PostsモデルにCacheとの連携を追加
* Comment更新時に、Postsを呼ぶように修正 