### PR TITLE
🐳 Dockerイメージを共通化とlinks機能の廃止対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ init:
 	docker-compose exec $(container) php artisan key:generate
 	docker-compose exec $(container) php artisan migrate
 
-up:build
+up:
 	docker-compose up -d
 
 down:
 	docker-compose down
 
 build:
-	docker-compose build
+	docker build -t juve534/php-fpm:7.3 .
 
 ps:
 	docker-compose ps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.7"
 
 services:
   nginx:
@@ -6,8 +6,8 @@ services:
     volumes:
       - ./docker/nginx/:/etc/nginx/conf.d/
       - ./public:/var/www/laravel/public
-    links:
-      - phpfpm
+    networks:
+      - sampleapp_net
     depends_on:
       - phpfpm
   phpfpm:
@@ -15,8 +15,8 @@ services:
     volumes:
       - ./:/var/www/html
       - ./docker/phpfpm/php.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-    links:
-      - mysql
+    networks:
+      - sampleapp_net
     depends_on:
       - mysql
     environment:
@@ -32,10 +32,16 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=pass
       - MYSQL_DATABASE=homestead
+    networks:
+      - sampleapp_net
+
   redis:
     image: redis:latest
     ports:
       - 6379:6379
+    networks:
+      - sampleapp_net
+
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.5.1
     ports:
@@ -43,20 +49,30 @@ services:
       - 9300:9300
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    networks:
+      - sampleapp_net
+
   # ElasticMQ
   elasticmq:
     image: softwaremill/elasticmq
     volumes:
       - ./docker/elasticmq/custom.conf://opt/elasticmq.conf:ro
+    networks:
+      - sampleapp_net
+
   queue-worker:
     image: juve534/php-fpm:7.3
     volumes:
       - ./:/var/www/html
       - ./docker/phpfpm/php.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-    links:
-      - mysql
+    networks:
+      - sampleapp_net
     depends_on:
       - mysql
       - elasticmq
     command: ["php", "artisan", "queue:work"]
     restart: always
+
+networks:
+  sampleapp_net:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,7 @@ services:
     depends_on:
       - phpfpm
   phpfpm:
-    build:
-      context: .
-      dockerfile: ./Dockerfile
+    image: juve534/php-fpm:7.3
     volumes:
       - ./:/var/www/html
       - ./docker/phpfpm/php.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
@@ -51,9 +49,7 @@ services:
     volumes:
       - ./docker/elasticmq/custom.conf://opt/elasticmq.conf:ro
   queue-worker:
-    build:
-      context: .
-      dockerfile: ./Dockerfile
+    image: juve534/php-fpm:7.3
     volumes:
       - ./:/var/www/html
       - ./docker/phpfpm/php.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini


### PR DESCRIPTION
WebとWorkerで同一イメージを使う.
毎回生成されていたので、それを解消.

docker-composeを修正するので、合わせてlinks機能を廃止し、networksを追加.